### PR TITLE
Remove Session config from Activate Admin

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -110,7 +110,14 @@ module ActivateAdmin
           end
         }
         if active_record?
-          @resources = @resources.where.any_of(*query) if !query.empty?
+          if !query.empty?
+            head, *tail = query
+            sub_resources = @resources.where(head) # add at least one concrete condition
+            tail.each do |cond|
+              sub_resources = sub_resources.or(@resources.where(cond))
+            end
+            @resources = sub_resources
+          end
         elsif mongoid?
           @resources = @resources.or(query)
         end
@@ -283,7 +290,14 @@ module ActivateAdmin
         end
       when 'any'
         if active_record?
-          @resources = @resources.where.any_of(*query) if !query.empty?
+          if !query.empty?
+            head, *tail = query
+            sub_resources = @resources.where(head) # add at least one concrete condition
+            tail.each do |cond|
+              sub_resources = sub_resources.or(@resources.where(cond))
+            end
+            @resources = sub_resources
+          end
         elsif mongoid?
           @resources = @resources.or(query)
         end

--- a/app/app.rb
+++ b/app/app.rb
@@ -10,8 +10,6 @@ module ActivateAdmin
 
     if ENV['SSL']
       use Rack::SslEnforcer
-    else
-      set :sessions, :expire_after => 1.year
     end
 
     def initialize

--- a/app/app.rb
+++ b/app/app.rb
@@ -391,7 +391,7 @@ module ActivateAdmin
       if account = Account.authenticate(params[:email], params[:password])
         session[:account_id] = account.id
         flash[:notice] = "Logged in successfully."
-        redirect url(:home)
+        redirect params[:redir] or url(:home)
       elsif Padrino.env == :development && params[:bypass]
         account = Account.first
         session[:account_id] = account.id

--- a/app/app.rb
+++ b/app/app.rb
@@ -8,11 +8,8 @@ module ActivateAdmin
     helpers Activate::ParamHelpers
     helpers Activate::NavigationHelpers
 
-    enable :sessions
-
     if ENV['SSL']
       use Rack::SslEnforcer
-      use Rack::Session::Cookie, :key => '_rack_session', :path => '/', :expire_after => 30*24*60*60, :secret => ENV['SESSION_SECRET']
     else
       set :sessions, :expire_after => 1.year
     end

--- a/app/app.rb
+++ b/app/app.rb
@@ -13,7 +13,7 @@ module ActivateAdmin
     end
 
     def initialize
-      unless ActiveRecord::Base.connection.active?
+      unless ActiveRecord::Base.connection.active? || ActiveRecord::Base.connection_pool.active_connection?
         if ENV['DATABASE_URL'] and ENV['DATABASE_SCHEMA']
           ActiveRecord::Base.establish_connection(ENV['DATABASE_URL'])
           ActiveRecord::Base.connection.schema_search_path = ENV['DATABASE_SCHEMA']

--- a/app/views/login.erb
+++ b/app/views/login.erb
@@ -1,6 +1,10 @@
 
 <% form_tag url(:login), :class => 'form-horizontal' do %>
 
+  <% if params[:redir] %>
+    <%= hidden_field_tag :redir, :value => params[:redir] %>
+  <% end %>
+
   <div class="form-group">
     <label class="control-label col-sm-3">Email</label>
     <div class="col-sm-3">


### PR DESCRIPTION
⚠️  This change should only be combined with its [companion change in Speakout](https://github.com/the-open/speakout/pull/1780). It would be bad to merge/deploy this change on its own ⚠️ 

There are, broadly, two small changes here. If desired, I can separate them into 2 PRs, but it's more convenient if it's OK to combine them.

- Remove all session config from Activate Admin - this leaves room for the parent app (e.g., Speakout) to control all session config
- Adjust login redirects - this seems like it was *always* broken, but this change fixes it, we needed to pass through the `redir` param, and pay attention to it with real/production logins