### PR TITLE
Don't redirect to same resource after it is deleted

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -385,7 +385,7 @@ module ActivateAdmin
           flash[:error] = "<strong>Darn!</strong> The #{human_model_name(model).downcase} couldn't be deleted."
         end
       end
-      params[:popup] ? closePopup : redirect(url(:edit, :model => model.to_s, :id => @resource.id))
+      params[:popup] ? closePopup : redirect(url(:index, :model => model.to_s))
     end
 
     get :login, :map => '/login' do


### PR DESCRIPTION
This is primarily a usability improvement. Deletion *works* currently, but it shows an error page because `@resource` does not exist (and even if it did, redirect to edit the resource you just deleted doesn't make a whole lot of sense).