### PR TITLE
Remove dependency on activerecord_any_of

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Setup
 In the Gemfile of your application:
 ```
 gem 'will_paginate', github: 'mislav/will_paginate'
-gem 'activerecord_any_of', github: 'oelmekki/activerecord_any_of' # if using ActiveRecord
 gem 'activate-tools', github: 'wordsandwriting/activate-tools'
 gem 'activate-admin', github: 'wordsandwriting/activate-admin'
 ```

--- a/app/app.rb
+++ b/app/app.rb
@@ -115,7 +115,14 @@ module ActivateAdmin
           end
         }
         if active_record?
-          @resources = @resources.where.any_of(*query) if !query.empty?
+          if !query.empty?
+            head, *tail = query
+            sub_resources = @resources.where(head) # add at least one concrete condition
+            tail.each do |cond|
+              sub_resources = sub_resources.or(@resources.where(cond))
+            end
+            @resources = sub_resources
+          end
         elsif mongoid?
           @resources = @resources.or(query)
         end
@@ -288,7 +295,14 @@ module ActivateAdmin
         end
       when 'any'
         if active_record?
-          @resources = @resources.where.any_of(*query) if !query.empty?
+          if !query.empty?
+            head, *tail = query
+            sub_resources = @resources.where(head) # add at least one concrete condition
+            tail.each do |cond|
+              sub_resources = sub_resources.or(@resources.where(cond))
+            end
+            @resources = sub_resources
+          end
         elsif mongoid?
           @resources = @resources.or(query)
         end


### PR DESCRIPTION
This dependency doesn't support AR 6, and likely never will. I've added a naive AR implementation inline using `or` instead. Really I'm most concerned with single condition cases continuing to work instead of throwing errors, but I welcome any comments to improve this.